### PR TITLE
chart: Fix lockc version

### DIFF
--- a/charts/lockc/Chart.yaml
+++ b/charts/lockc/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: lockc
-version: 0.1.1
+version: 0.1.4
 description: A Helm chart for Kubernetes lockc agent and daemon
 type: application
 icon: https://github.com/rancher-sandbox/lockc/blob/main/docs/src/images/logo-horizontal-lockc.png


### PR DESCRIPTION
The current lockc version is 0.1.4, let's stick to it and adjust the tag
in this repo.

Signed-off-by: Michal Rostecki <mrostecki@opensuse.org>