### PR TITLE
daemonset: Add runc path used by torcx and Flatcar Linux

### DIFF
--- a/charts/lockc/templates/daemonset.yaml
+++ b/charts/lockc/templates/daemonset.yaml
@@ -35,16 +35,10 @@ spec:
 {{- end }}
         - name: bpffs
           mountPath: /sys/fs/bpf
-        - name: bin-runc
-          mountPath: /host/usr/bin/runc
-        - name: sbin-runc
-          mountPath: /host/usr/sbin/runc
-        - name: local-bin-runc
-          mountPath: /host/usr/local/bin/runc
-        - name: local-sbin-runc
-          mountPath: /host/usr/local/sbin/runc
-        - name: run-containerd-bundle
-          mountPath: /run/containerd/io.containerd.runtime.v2.task
+        - name: usr
+          mountPath: /host/usr
+        - name: run
+          mountPath: /host/run
       serviceAccountName: {{ include "lockc.serviceAccountName" . }}
       tolerations:
       - operator: Exists
@@ -58,18 +52,11 @@ spec:
         hostPath:
           path: /sys/fs/bpf
           type: Directory
-      - name: bin-runc
+      - name: usr
         hostPath:
-          path: /usr/bin/runc
-      - name: sbin-runc
+          path: /usr
+          type: Directory
+      - name: run
         hostPath:
-          path: /usr/sbin/runc
-      - name: local-bin-runc
-        hostPath:
-          path: /usr/local/bin/runc
-      - name: local-sbin-runc
-        hostPath:
-          path: /usr/local/sbin/runc
-      - name: run-containerd-bundle
-        hostPath:
-          path: /run/containerd/io.containerd.runtime.v2.task
+          path: /run
+          type: Directory


### PR DESCRIPTION
Flatcar Linux uses torcx[0] to install addons on immutable Linux
distributions and one of them is runc. To support Flatcar, we need to
monitor runc path comming from torcx as well.

[0] https://github.com/flatcar-linux/torcx

Fixes: rancher-sandbox/lockc-helm-charts#9
Signed-off-by: Michal Rostecki <mrostecki@opensuse.org>