### PR TITLE
Ensure that lockc namespace is privileged

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,8 +7,9 @@ For more information refer to the [official lockc website](https://rancher-sandb
 
 For example:
 ```console
+$ kubectl apply -f https://rancher-sandbox.github.io/lockc-helm-charts/namespace.yaml
 $ helm repo add lockc https://rancher-sandbox.github.io/lockc-helm-charts/
-$ helm install --create-namespace -n lockc lockc lockc/lockc
+$ helm install -n lockc lockc lockc/lockc
 ```
 
 If it is necessary to change lockcd config please create `lockc.toml` or copy it from

--- a/namespace.yaml
+++ b/namespace.yaml
@@ -1,0 +1,12 @@
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: lockc
+  labels:
+    pod-security.kubernetes.io/enforce: privileged
+    pod-security.kubernetes.io/enforce-version: v1.23
+    pod-security.kubernetes.io/audit: privileged
+    pod-security.kubernetes.io/audit-version: v1.23
+    pod-security.kubernetes.io/warn: privileged
+    pod-security.kubernetes-io/warn-version: v1.23


### PR DESCRIPTION
For now it's maybe not so important, but in the future we might want to
enforce lockc policies on the already deployed k8s pods somehow. When
that happens, we need to make sure that the `lockc` k8s namespace
applies privileged policy by default.

Since Helm doesn't provide any way to create namespaces without helmfile
(which might be too much effort for users), we are just providing a
vanilla yaml with the namespace. It's just one command more.

Signed-off-by: Michal Rostecki <mrostecki@opensuse.org>